### PR TITLE
fixes for react 17 type errors

### DIFF
--- a/packages/cli/src/generator_templates/ts/emails/TextEmail.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/TextEmail.tsx
@@ -22,7 +22,7 @@ import {
 type TextEmailProps = {
   name: string;
   headline?: string;
-  body: ReactElement;
+  body: any; // n.b. ReactElement/ReactNode break on react 17
   bulletedList?: ReactElement;
   ctaText?: string;
 };

--- a/packages/cli/src/generator_templates/ts/emails/components/Head.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/components/Head.tsx
@@ -13,11 +13,12 @@ type HeadProps = { children?: ReactElement };
 const Head: React.FC<HeadProps> = ({ children }) => {
   return (
     <MjmlHead>
-      <MjmlFont
-        name="Inter"
-        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;900"
-      />
-      <MjmlStyle>{`
+      <>
+        <MjmlFont
+          name="Inter"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;900"
+        />
+        <MjmlStyle>{`
         .smooth {
           -webkit-font-smoothing: antialiased;
         }
@@ -40,13 +41,14 @@ const Head: React.FC<HeadProps> = ({ children }) => {
           }
         }
       `}</MjmlStyle>
-      <MjmlAttributes>
-        <MjmlAll
-          font-family='Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
-          font-weight="400"
-        />
-      </MjmlAttributes>
-      {children}
+        <MjmlAttributes>
+          <MjmlAll
+            font-family='Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+            font-weight="400"
+          />
+        </MjmlAttributes>
+        {children}
+      </>
     </MjmlHead>
   );
 };


### PR DESCRIPTION
This was breaking when I made a remix app with `npx create-remix@latest`. Maybe the remix app I had tested was react 18?

It would be cool to have cypress smoke tests for multiple react versions.