### PR TITLE
fix peer deps, remove type dependency to defer to user types

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,14 +35,12 @@
     "@types/node-fetch": "^2.6.1",
     "@types/nodemailer": "^6.4.4",
     "@types/prompts": "^2.0.14",
-    "@types/react": "^18.0.15",
-    "@types/react-dom": "^18.0.6",
     "@types/yargs": "^17.0.10",
     "cypress": "^10.3.1"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "chalk": "^4.1.2",


### PR DESCRIPTION
The fix from #53 works but warns about incorrect peer deps. This is more flexible about allowing react 17 and does not warn.

I tested with yalc and it didn't work. Tested by pushing to `0.4.12-beta.0` and it worked 🤦.