### PR TITLE
No react imports

### DIFF
--- a/babel.config.json
+++ b/babel.config.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "@babel/react",
+    ["@babel/react", { "runtime": "automatic" }],
     ["@babel/preset-typescript", { "isTSX": true, "allExtensions": true }],
     "@babel/preset-env"
   ]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -103,7 +103,6 @@ Mailing includes a development mode for working on your emails. Running `mailing
 For example, here's `emails/previews/Welcome.tsx`:
 
 ```tsx
-import React from "react";
 import Welcome from "../Welcome";
 
 export function toAmelita() {
@@ -114,7 +113,6 @@ export function toAmelita() {
 It will show up in the index:
 
 <img width="600" alt="Mailing index" src="https://user-images.githubusercontent.com/609038/181653058-266ed86b-3a39-4a9d-b2df-afa2273bf040.jpg">
-
 
 Clicking through shows you the email with a mobile/desktop toggle and live reload as you edit:
 
@@ -226,4 +224,3 @@ For development, you may want to have a demo next app that pulls in your changes
 - Make your changes in `mailing`
 - Run `yarn build` in the `mailing` root directory to create new `dist` files
 - Run `yalc push` in the `mailing` root directory to both publish your changes (`yalc publish`) and pull them in to your next app (`yalc update`)
-

--- a/packages/cli/dist/mailing.cjs.dev.js
+++ b/packages/cli/dist/mailing.cjs.dev.js
@@ -847,14 +847,17 @@ var handler$1 = /*#__PURE__*/function () {
               require("ts-node").register({
                 compilerOptions: {
                   module: "commonjs",
-                  jsx: "react",
+                  jsx: "react-jsx",
                   moduleResolution: "node",
                   skipLibCheck: true
                 }
               });
 
               require("@babel/register")({
-                presets: ["@babel/react", "@babel/preset-env"]
+                presets: [["@babel/react", {
+                  runtime: "automatic"
+                }], "@babel/preset-env"],
+                compact: false
               });
             }
 
@@ -989,7 +992,7 @@ var handler$1 = /*#__PURE__*/function () {
                         break;
 
                       case 40:
-                        if (!/^\/_next/.test(req.url)) {
+                        if (!/^\/_+next/.test(req.url)) {
                           _context.next = 46;
                           break;
                         }

--- a/packages/cli/dist/mailing.cjs.prod.js
+++ b/packages/cli/dist/mailing.cjs.prod.js
@@ -845,14 +845,17 @@ var handler$1 = /*#__PURE__*/function () {
               require("ts-node").register({
                 compilerOptions: {
                   module: "commonjs",
-                  jsx: "react",
+                  jsx: "react-jsx",
                   moduleResolution: "node",
                   skipLibCheck: true
                 }
               });
 
               require("@babel/register")({
-                presets: ["@babel/react", "@babel/preset-env"]
+                presets: [["@babel/react", {
+                  runtime: "automatic"
+                }], "@babel/preset-env"],
+                compact: false
               });
             }
 
@@ -987,7 +990,7 @@ var handler$1 = /*#__PURE__*/function () {
                         break;
 
                       case 40:
-                        if (!/^\/_next/.test(req.url)) {
+                        if (!/^\/_+next/.test(req.url)) {
                           _context.next = 46;
                           break;
                         }

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -44,14 +44,23 @@ export const handler = async (argv: PreviewArgs) => {
     require("ts-node").register({
       compilerOptions: {
         module: "commonjs",
-        jsx: "react",
+        jsx: "react-jsx",
         moduleResolution: "node",
         skipLibCheck: true,
       },
     });
 
     require("@babel/register")({
-      presets: ["@babel/react", "@babel/preset-env"],
+      presets: [
+        [
+          "@babel/react",
+          {
+            runtime: "automatic",
+          },
+        ],
+        "@babel/preset-env",
+      ],
+      compact: false,
     });
   }
 
@@ -131,7 +140,7 @@ export const handler = async (argv: PreviewArgs) => {
           showIntercept(req, res);
         } else if (/^\/previews\/.*\.json/.test(req.url)) {
           showPreview(req, res);
-        } else if (/^\/_next/.test(req.url)) {
+        } else if (/^\/_+next/.test(req.url)) {
           noLog = true;
           await app.render(req, res, `${pathname}`, query);
         } else {

--- a/packages/cli/src/components/HotIFrame.tsx
+++ b/packages/cli/src/components/HotIFrame.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import usePreviewHotkeys from "./hooks/usePreviewHotkeys";
 
 type HotIFrameProps = {

--- a/packages/cli/src/components/MjmlErrors.tsx
+++ b/packages/cli/src/components/MjmlErrors.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 type MjmlErrorsProps = {
   errors: Array<MjmlError>;
 };

--- a/packages/cli/src/dev.js
+++ b/packages/cli/src/dev.js
@@ -6,13 +6,22 @@ process.env.MM_DEV = 1;
 require("ts-node").register({
   compilerOptions: {
     module: "commonjs",
-    jsx: "react",
+    jsx: "react-jsx",
     moduleResolution: "node",
     skipLibCheck: true,
   },
 });
 
 require("@babel/register")({
-  presets: ["@babel/react", "@babel/preset-env"],
+  presets: [
+    [
+      "@babel/react",
+      {
+        runtime: "automatic",
+      },
+    ],
+    "@babel/preset-env",
+  ],
+  compact: false,
 });
 require("./index.ts");

--- a/packages/cli/src/generator_templates/js/emails/TextEmail.jsx
+++ b/packages/cli/src/generator_templates/js/emails/TextEmail.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Head from "./components/Head";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
@@ -19,13 +18,7 @@ import {
   MjmlSpacer,
 } from "mjml-react";
 
-const TextEmail = ({
-  name,
-  headline,
-  body,
-  bulletedList,
-  ctaText,
-}) => {
+const TextEmail = ({ name, headline, body, bulletedList, ctaText }) => {
   return (
     <Mjml>
       <Head />

--- a/packages/cli/src/generator_templates/js/emails/Welcome.jsx
+++ b/packages/cli/src/generator_templates/js/emails/Welcome.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Head from "./components/Head";
 import Header from "./components/Header";
 import Footer from "./components/Footer";

--- a/packages/cli/src/generator_templates/js/emails/components/BulletedList.jsx
+++ b/packages/cli/src/generator_templates/js/emails/components/BulletedList.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlText } from "mjml-react";
 import { leadingRelaxed, textBase } from "./theme";
 

--- a/packages/cli/src/generator_templates/js/emails/components/ButtonPrimary.jsx
+++ b/packages/cli/src/generator_templates/js/emails/components/ButtonPrimary.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlButton } from "mjml-react";
 import { black } from "./theme";
 import { leadingTight, textBase, borderBase } from "./theme";

--- a/packages/cli/src/generator_templates/js/emails/components/Footer.jsx
+++ b/packages/cli/src/generator_templates/js/emails/components/Footer.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlSection, MjmlColumn, MjmlText } from "mjml-react";
 import { grayDark, textSm } from "./theme";
 

--- a/packages/cli/src/generator_templates/js/emails/components/Head.jsx
+++ b/packages/cli/src/generator_templates/js/emails/components/Head.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   MjmlHead,
   MjmlFont,

--- a/packages/cli/src/generator_templates/js/emails/components/Header.jsx
+++ b/packages/cli/src/generator_templates/js/emails/components/Header.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlSection, MjmlColumn, MjmlImage } from "mjml-react";
 
 const Header = ({ big }) => {

--- a/packages/cli/src/generator_templates/js/emails/previews/TextEmail.jsx
+++ b/packages/cli/src/generator_templates/js/emails/previews/TextEmail.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import TextEmail from "../TextEmail";
 import BulletedList from "../components/BulletedList";
 

--- a/packages/cli/src/generator_templates/js/emails/previews/Welcome.jsx
+++ b/packages/cli/src/generator_templates/js/emails/previews/Welcome.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Welcome from "../Welcome";
 
 export function toAmelita() {

--- a/packages/cli/src/generator_templates/ts/emails/TextEmail.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/TextEmail.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import Head from "./components/Head";
 import Header from "./components/Header";
 import Footer from "./components/Footer";

--- a/packages/cli/src/generator_templates/ts/emails/Welcome.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/Welcome.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Head from "./components/Head";
 import Header from "./components/Header";
 import Footer from "./components/Footer";

--- a/packages/cli/src/generator_templates/ts/emails/components/BulletedList.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/components/BulletedList.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlText } from "mjml-react";
 import { leadingRelaxed, textBase } from "./theme";
 

--- a/packages/cli/src/generator_templates/ts/emails/components/ButtonPrimary.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/components/ButtonPrimary.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlButton } from "mjml-react";
 import { black } from "./theme";
 import { leadingTight, textBase, borderBase } from "./theme";

--- a/packages/cli/src/generator_templates/ts/emails/components/Footer.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/components/Footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlSection, MjmlColumn, MjmlText } from "mjml-react";
 import { grayDark, textSm } from "./theme";
 

--- a/packages/cli/src/generator_templates/ts/emails/components/Header.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/components/Header.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { MjmlSection, MjmlColumn, MjmlImage } from "mjml-react";
 
 type HeaderProps = {

--- a/packages/cli/src/generator_templates/ts/emails/previews/TextEmail.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/previews/TextEmail.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import TextEmail from "../TextEmail";
 import BulletedList from "../components/BulletedList";
 

--- a/packages/cli/src/generator_templates/ts/emails/previews/Welcome.tsx
+++ b/packages/cli/src/generator_templates/ts/emails/previews/Welcome.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import Welcome from "../Welcome";
 
 export function toAmelita() {

--- a/packages/core/src/__test__/index.test.tsx
+++ b/packages/core/src/__test__/index.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import nodemailer from "nodemailer";
 
 import {

--- a/packages/core/src/__test__/render.test.tsx
+++ b/packages/core/src/__test__/render.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "../index";
 import { Mjml, MjmlBody, MjmlRaw } from "mjml-react";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
     "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "isolatedModules": true,
-    "jsx": "react" /* Specify what JSX code is generated. */,
+    "jsx": "react-jsx" /* Specify what JSX code is generated. */,
     "module": "commonjs" /* Specify what module code is generated. */,
     "rootDir": "./src" /* Specify the root folder within your source files. */,
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,


### PR DESCRIPTION
This fixes #73 by switching to the modern automatic jsx runtime.

Redwood, next, and remix all support this.

tested ts and js

Also, cleaned up some over-logging that babel and next were causing:
<img width="872" alt="Screen Shot 2022-08-03 at 1 25 21 PM" src="https://user-images.githubusercontent.com/282016/182708166-ae055045-1fa5-412a-84c1-f66f7a1eef25.png">
<img width="1222" alt="Screen Shot 2022-08-03 at 1 45 23 PM" src="https://user-images.githubusercontent.com/282016/182708269-98cdb6d4-cff6-4ef4-9163-828da4d3d28a.png">

